### PR TITLE
Change terminators to line feed

### DIFF
--- a/system_tests/lewis_emulators/dhp30330/interfaces/stream_interface.py
+++ b/system_tests/lewis_emulators/dhp30330/interfaces/stream_interface.py
@@ -7,8 +7,8 @@ from lewis.utils.replies import conditional_reply
 @has_log
 class Dhp30330StreamInterface(StreamInterface):
     
-    in_terminator = "\r"
-    out_terminator = "\r"
+    in_terminator = "\n"
+    out_terminator = "\n"
 
     def __init__(self):
         super(Dhp30330StreamInterface, self).__init__()


### PR DESCRIPTION
Me and Jack has fixed the terminators when testing with real device in the proto file but have forgot to change it in the emulator.